### PR TITLE
Add `thelounge-plugin` keyword to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "keywords": [
     "thelounge",
+    "thelounge-plugin",
     "irc",
     "exec"
   ],


### PR DESCRIPTION
I found this plugin by chance and realized I never saw it on https://www.npmjs.com/search?q=keywords%3Athelounge-plugin. If it works, it'd be a great addition to the (small) list. 